### PR TITLE
Temporarily add Optimizely js directly to the page to preview experiment

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
 
         <meta name="twitter:card" content="summary_large_image">
 
+        <script src="https://cdn.optimizely.com/js/3867211201.js"></script>
+
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-125321641-1"></script>
         <script>

--- a/new.html
+++ b/new.html
@@ -37,6 +37,8 @@
         <script src="//1.www.s81c.com/common/v18/js/www.js"></script>
         <link href="https://1.www.s81c.com/common/v18/css/grid-fluid.css" rel="stylesheet">
 
+        <script src="https://cdn.optimizely.com/js/3867211201.js"></script>
+
         <script>
             digitalData = {
                 page: {


### PR DESCRIPTION
Temporarily embedded Optimizely js into the page so that it can be previewed in the app and the validity of the experiment confirmed.
This will be REMOVED and replaced with the Digital Registry assigned fragment once approved.
(The experiment is not running by doing this since it hasn't been published).