### PR TITLE
Move to ibm.biz redirects to capture referrer and country information

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/386657/Senior-Full-Stack-Web-Developer/" id="Senior-Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="https://ibm.biz/CIO-London-Senior-Full-Stack-Web-Developer" id="Senior-Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/dev.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-bold">Senior Full Stack Web Developer</h1>
                                                     <p class="ibm-textcolor-gray-40 ibm-light">You’re a senior full-stack web developer who delivers to the highest standard using the latest and most relevant technologies. Your solutions are scalable and maintainable and you enjoy collaborating with designers to produce best-in-class user experiences with pixel perfect accuracy.</p>
@@ -182,7 +182,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/386660/Full-Stack-Web-Developer/" id="Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="https://ibm.biz/CIO-London-Full-Stack-Web-Developer" id="Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/dev.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-bold">Full Stack Web Developer</h1>
                                                     <p class="ibm-textcolor-gray-40 ibm-light">You’re a web developer who delivers to the highest standard using the latest and most relevant technologies. You enjoy tackling complex problems and crafting their solutions, and you enjoy collaborating with designers to produce best-in-class user experiences with pixel perfect accuracy.</p>
@@ -196,7 +196,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/205523/UI-UX-Designer" id="UI-UX-Designer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="http://ibm.biz/CIO-London-UI-UX-Designer" id="UI-UX-Designer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/design.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-bold">UI/UX Designer</h1>
                                                     <p class="ibm-textcolor-gray-40 ibm-light">You’re a visual problem solver and you champion the user in every choice you make. As the lead UI/UX designer on your team, you enjoy working alongside developers and are confident speaking to the value of your work to a room full of stakeholders.</p>
@@ -210,7 +210,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/381744/UX-Researcher/" id="UX-Researcher" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="http://ibm.biz/CIO-London-UX-Researcher" id="UX-Researcher" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/design.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-bold">UX Researcher</h1>
                                                     <p class="ibm-textcolor-gray-40 ibm-light">You’re a dedicated UX researcher who is passionate about understanding your users and getting to the roots of their pain points. You’re a skilled interviewer and user tester who knows how to craft the right questions to elicit the most relevant information from your subjects.</p>
@@ -224,7 +224,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a style="display: none;" href="https://careers.ibm.com/ShowJob/Id/304951/Business-Analyst/" id="Business-Analyst" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a style="display: none;" href="https://ibm.biz/CIO-London-Business-Analyst" id="Business-Analyst" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/ba.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-bold">Business Analyst</h1>
                                                     <p class="ibm-textcolor-gray-40 ibm-light">You’re an analytical thinker and negotiator who effectively communicates complex ideas to both technical and non-technical audiences. You maintain your team’s focus on delivering to business results, and are committed to becoming a trusted partner of the product owner.</p>

--- a/new.html
+++ b/new.html
@@ -192,7 +192,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/386657/Senior-Full-Stack-Web-Developer/" id="Senior-Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="https://ibm.biz/CIO-London-Senior-Full-Stack-Web-Developer" id="Senior-Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/dev-blue.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-padding-bottom-0 ibm-bold">Senior Full Stack Web Developers</h3>
                                                     <h4 class="ibm-padding-bottom-0 ibm-padding-top-0">Application closing soon. Submit your CV now.</h4>
@@ -205,7 +205,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/386660/Full-Stack-Web-Developer/" id="Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="https://ibm.biz/CIO-London-Full-Stack-Web-Developer" id="Full-Stack-Web-Developer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/dev-blue.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-padding-bottom-0 ibm-bold">Full Stack Web Developers</h3>
                                                     <h4 class="ibm-padding-bottom-0 ibm-padding-top-0">Application closing soon. Submit your CV now.</h4>
@@ -218,7 +218,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/205523/UI-UX-Designer/" id="UI-UX-Designer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="http://ibm.biz/CIO-London-UI-UX-Designer" id="UI-UX-Designer" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/design-blue.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-padding-bottom-0 ibm-bold">UX/UI Designers</h3>
                                                     <p class="ibm-textcolor-blue-80 ibm-light ibm-padding-top-1 ibm-padding-bottom-2">You’re a visual problem solver and you champion the user in every choice you make. As the lead UI/UX designer on your team, you enjoy working alongside developers and are confident speaking to the value of your work to a room full of stakeholders.</p>
@@ -230,7 +230,7 @@
 
                                         <div class="ibm-col-12-4 ibm-col-medium-12-6">
                                             <div class="ibm-card ibm-card--noborder">
-                                                <a href="https://careers.ibm.com/ShowJob/Id/381744/UX-Researcher/" id="UX-Researcher" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
+                                                <a href="http://ibm.biz/CIO-London-UX-Researcher" id="UX-Researcher" target="_blank" rel="noopener noreferrer" class="ibm-blocklink ibm-padding-content">
                                                     <img src="assets/images/design-blue.svg" alt="" class="ibm-padding-bottom-1">
                                                     <h3 class="ibm-padding-top-1 ibm-bold">UX Researchers</h3>
                                                     <p class="ibm-textcolor-blue-80 ibm-light ibm-padding-top-1 ibm-padding-bottom-2">You’re a dedicated UX researcher who is passionate about understanding your users and getting to the roots of their pain points. You’re a skilled interviewer and user tester who knows how to craft the right questions to elicit the most relevant information from your subjects.</p>


### PR DESCRIPTION
Migrated all links to ibm.biz shortened urls as opposed to direct BrassRing links so that;
the ibm.biz url captures referrer and country information
the ibm.biz url can be given directly to people knowing it will always point to the right BR req (assuming it's kept in sync).